### PR TITLE
Add Python requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests==2.5.3
+slimit==0.8.1
+tldextract==1.5.1


### PR DESCRIPTION
Using a requirements.txt file for the Python requirements, makes it easier to install them in a virtualenv to start development. The versions are also pinned to an exact number, to avoid surprises.

Right now they are defined in stackato.yml and pip can't use it to install them.

I think having the requirements.txt might be enough for the deployment with stackato, so python requirement entries could be removed from the stackato yaml file. Plus, there is no much benefit in using pypm, since the dependencies don't need any compiling during installation.