### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Helps with setting the text editor with the correct settings when someone contributes in a project. There are [plugins for most text editors](http://editorconfig.org/#download) that read this config. More info about it at http://editorconfig.org

The settings for python is what pretty much every python project is using, but please adjust the global one to your preferences. I could not figure out what it should be, as right now it's inconsistent between the different files.